### PR TITLE
Update workshop session info and schedule in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,20 @@ Washington, DC 20001, United States
 
 ## Schedule
 
-|  Time (EST) | Event                                                 |
-|:------------|:------------------------------------------------------|
-| 08:30-17:00 | TODO                                                  |
+|  Time (EST) | Topic                                                   |
+|:-----------:|:-------------------------------------------------------:|
+| 08:30-08:40 | Introduction to GMT/PyGMT                               |
+| 08:40-08:55 | Installation                                            |
+| 08:55-09:45 | Tutorial 1 - First figure + Subplots/layout             |
+| 09:45-10:15 | **Break**                                               |
+| 10:15-11:00 | Tutorial 2 - Integration with Scientific Python Ecosystem: Pandas/Geopandas |
+| 11:00-11:45 | Tutorial 3 - Integration with Scientific Python Ecosystem: Xarray (grids)   |
+| 11:45-12:45 | **Lunch**                                               |
+| 12:45-13:30 | Tutorial 4 - Geophysics (Seismology)                    |
+| 13:30-14:15 | Tutorial 5 - 3D Topography (Planetary / Antarctic Maps) |
+| 14:15-14:45 | **Break**                                               |
+| 14:45-15:30 | Tutorial 6 - Animations with GMT                        |
+| 15:30-17:00 | Final exercises / mini-project                          |
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ Washington, DC 20001, United States
 
 |  Time (EST) | Topic                                                   |
 |:-----------:|:-------------------------------------------------------:|
-| 08:30-08:40 | Introduction to GMT/PyGMT                               |
+| 08:30-08:40 | Introduction to GMT / PyGMT                             |
 | 08:40-08:55 | Installation                                            |
-| 08:55-09:45 | Tutorial 1 - First figure + Subplots/layout             |
+| 08:55-09:45 | Tutorial 1 - First figure + Subplots / layout           |
 | 09:45-10:15 | **Break**                                               |
-| 10:15-11:00 | Tutorial 2 - Integration with Scientific Python Ecosystem: Pandas/Geopandas |
-| 11:00-11:45 | Tutorial 3 - Integration with Scientific Python Ecosystem: Xarray (grids)   |
+| 10:15-11:00 | Tutorial 2 - Integration with scientific Python ecosystem: Pandas / GeoPandas |
+| 11:00-11:45 | Tutorial 3 - Integration with scientific Python ecosystem: Xarray (grids)     |
 | 11:45-12:45 | **Lunch**                                               |
 | 12:45-13:30 | Tutorial 4 - Geophysics (Seismology)                    |
-| 13:30-14:15 | Tutorial 5 - 3D Topography (Planetary / Antarctic Maps) |
+| 13:30-14:15 | Tutorial 5 - 3-D Topography (Planetary / Antarctic Maps) |
 | 14:15-14:45 | **Break**                                               |
 | 14:45-15:30 | Tutorial 6 - Animations with GMT                        |
 | 15:30-17:00 | Final exercises / mini-project                          |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Material for the
 [GMT](https://www.generic-mapping-tools.org)/[PyGMT](https://www.pygmt.org)
-pre-conference workshop at the
+pre-conference workshop (PREWS9) at the
 [AGU24 Annual Meeting](https://www.agu.org/annual-meeting).
 
 **Presenters**
@@ -20,10 +20,10 @@ pre-conference workshop at the
 - Sunday 8 December 2024, 8:30-17:00 (EST) / 13:10-22:00 (UTC)
 - [Event Time Zone Converter](https://www.timeanddate.com/worldclock/fixedtime.html?msg=AGU24+workshop%3A+Mastering+Geospatial+Visualizations+with+GMT%2FPyGMT&iso=20241208T0830&p1=263&ah=8&am=30)
 
-**Where**: Walter E. Washington Convention Center, 801 Allen Y. Lew Place NW,
+**Where**: Liberty N-P (Marriott Marquis), 901 Massachusetts Avenue NW,
 Washington, DC 20001, United States
 
-**Website**: TODO
+**Website**: https://agu.confex.com/agu/agu24/meetingapp.cgi/Session/226736
 
 ## Schedule
 


### PR DESCRIPTION
Info for our PREWS9 session is now up on the AGU24 website! This PR updates:

- The workshop venue which will be at Liberty N-P (Marriott Marquis), 901 Massachusetts Avenue NW,
Washington, DC 20001, United States
- Link to the AGU session info - https://agu.confex.com/agu/agu24/meetingapp.cgi/Session/226736
- Workshop outline based on what was drafted at https://hackmd.io/@pygmt/agu24workshop_outline

The schedule itself might be tweaked a bit later, and we can add the presenter names in a follow-up PR around November when we finalize the tutorial contents.

