### PR TITLE
Tutorial 2 - Add code to show the usage of "Figure.plot"

### DIFF
--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -166,7 +166,7 @@
    "id": "b387494c-15ae-4019-83fc-bdf325f8a76d",
    "metadata": {},
    "source": [
-    "### 1.2 Create a geographical map showing the epicenters (scatter plot)\n",
+    "### 1.3 Create a geographical map showing the epicenters (scatter plot)\n",
     "\n",
     "Now it's time to create a geographical map showing the earthquakes. You can start with using [`pygmt.Figure.basemap`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.basemap.html) and [`pygmt.Figure.coast`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.coast.html) to set up the map. To create a scatter plot we can pass appropriate columns of the `pandas.DataFrame` to the `x`, `y`, `size`, and `fill` parameters of [`pygmt.Figure.plot`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.plot.html). This allows use to plot the epicenters as size (moment magnitude) and color (hypocentral depth) coded circles on top of the map. For details you can have a look at [**Plotting data points**](https://www.pygmt.org/v0.13.0/tutorials/basics/plot.html)."
    ]

--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -166,19 +166,37 @@
    "id": "b387494c-15ae-4019-83fc-bdf325f8a76d",
    "metadata": {},
    "source": [
-    "### 1.3 Create a geographical map of the earthquakes\n",
+    "### 1.2 Create a geographical map showing the epicenters (scatter plot)\n",
     "\n",
-    "Now it's time to create a geographical map showing the earthquakes. You can start with using [`pygmt.Figure.coast`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.coast.html) and [`pygmt.Figure.plot`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.plot.html). For plotting the earthquakes as size (moment magnitude) and color (hypocentral depth) coded circles on top of the map please follow the tutorial [**Plotting data points**](https://www.pygmt.org/v0.13.0/tutorials/basics/plot.html)."
+    "Now it's time to create a geographical map showing the earthquakes. You can start with using [`pygmt.Figure.basemap`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.basemap.html) and [`pygmt.Figure.coast`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.coast.html) to set up the map. To create a scatter plot we can pass appropriate columns of the `pandas.DataFrame` to the `x`, `y`, `size`, and `fill` parameters of [`pygmt.Figure.plot`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.plot.html). This allows use to plot the epicenters as size (moment magnitude) and color (hypocentral depth) coded circles on top of the map. For details you can have a look at [**Plotting data points**](https://www.pygmt.org/v0.13.0/tutorials/basics/plot.html)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "badc1a20-714f-49d9-955e-0cd730d158ba",
+   "id": "35f3d4b4-244c-4af7-8fae-3da1f9b45c49",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Your code (:"
+    "fig = pygmt.Figure()\n",
+    "fig.basemap(region=[131, 152, 33, 51], projection=\"M10c\", frame=True)\n",
+    "fig.coast(land=\"gray99\", shorelines=\"gray50\")\n",
+    "\n",
+    "pygmt.makecpt(cmap=\"SCM/navia\", series=[0, 500], reverse=True)\n",
+    "fig.colorbar(frame=[\"xa100f50+lhypocentral depth\", \"y+lkm\"], position=\"+ef0.2c\")\n",
+    "\n",
+    "# Plot the epicenters as color- and size-coded circels based on depth or magnitude\n",
+    "fig.plot(\n",
+    "    x=df_jp_eqs.longitude,\n",
+    "    y=df_jp_eqs.latitude,\n",
+    "    size=0.02 * 2**df_jp_eqs.magnitude,  # Note the exponential scaling\n",
+    "    fill=df_jp_eqs.depth_km,\n",
+    "    cmap=True,\n",
+    "    style=\"cc\",  # Use circles (fist \"c\") with diameter in centimeters (second \"c\")\n",
+    "    pen=\"gray10\",\n",
+    ")\n",
+    "\n",
+    "fig.show(dpi=img_dpi)"
    ]
   },
   {
@@ -501,7 +519,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While going through the tutorials I realized that we never introduce `Figure.plot`. The first time this method is used is in tutorial 2. There, people are directly asked to write their own code. I feel this is not optimal and added some code showing how to use `Figure.plot` together with a `pandas.DataFrame` to create a scatter plot (with color and size coding).  I also suggested to add the badges `scatter plot` to the card of Tutorial 2 in PR #12.