### PR TITLE
Increase code execution timeout from 90 to 270

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -5,6 +5,7 @@ name: deploy-book
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
   # pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -9,7 +9,7 @@ logo: logo.webp
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
-  timeout: 90  # https://jupyterbook.org/en/stable/content/execute.html#setting-execution-timeout
+  timeout: 270  # https://jupyterbook.org/en/stable/content/execute.html#setting-execution-timeout
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
Got some errors after merging #26, possibly due to some notebook cells taking too long to execute on CI and timing out:

```
/home/runner/work/agu24workshop/agu24workshop/book/tut03_spe_xarray.ipynb: WARNING: Executing notebook failed: CellExecutionError [mystnb.exec]
/home/runner/work/agu24workshop/agu24workshop/book/tut03_spe_xarray.ipynb: WARNING: Notebook exception traceback saved in: /home/runner/work/agu24workshop/agu24workshop/book/_build/html/reports/tut03_spe_xarray.err.log [mystnb.exec]
/home/runner/work/agu24workshop/agu24workshop/book/tut05_topography.ipynb: WARNING: Executing notebook failed: CellTimeoutError [mystnb.exec]
/home/runner/work/agu24workshop/agu24workshop/book/tut05_topography.ipynb: WARNING: Notebook exception traceback saved in: /home/runner/work/agu24workshop/agu24workshop/book/_build/html/reports/tut05_topography.err.log [mystnb.exec]
```

Hopefully 270 seconds (4.5min) is enough :pray: