### PR TITLE
Tutorial 5: Add bibliography reference section

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -44,6 +44,7 @@ html:
 
 sphinx:
   config:
+    bibtex_bibliography_header: ".. rubric:: References"
     bibtex_reference_style: author_year
     html_show_copyright: false
     # Adjust highlight language for sphinx_gmt examples

--- a/book/intro.md
+++ b/book/intro.md
@@ -95,7 +95,7 @@ and [Yvonne Fröhlich](https://orcid.org/0000-0002-8566-0619)
 :gutter: 1
 
 :::{grid-item-card} Tutorial 5 - 3-D Topography (Planetary / Antarctic maps)
-:img-top: _images/1dfddce0ff606bd7dc3a175aedbd2fc4bde3aeadfadfd339eb30ce1903d049f9.png
+:img-top: _images/0a6fc097b1fcaa99eff8632dab714787757564ed60e07f20825101c6a8e045ae.png
 :link: ./tut05_topography.html
 by [Wei Ji Leong](https://orcid.org/0000-0003-2354-1988)
 and [André Belém](https://orcid.org/0000-0002-8865-6180)

--- a/book/tut05_topography.ipynb
+++ b/book/tut05_topography.ipynb
@@ -418,6 +418,9 @@
     "- https://github.com/andrebelem/PlanetaryMaps/blob/main/2_%20Tutorial%20Mars%20Maps%20V2.ipynb\n",
     "- https://www.generic-mapping-tools.org/egu22pygmt/lidar_to_surface.html\n",
     "- https://www.pygmt.org/v0.13.0/tutorials/advanced/3d_perspective_image.html\n",
+    "```\n",
+    "\n",
+    "```{bibliography}\n",
     "```"
    ]
   }


### PR DESCRIPTION
Got several of these warnings, which means the in-text citation on Tutorial 5 wasn't showing up:

```
/home/runner/work/agu24workshop/agu24workshop/book/tut05_topography.ipynb:10011: WARNING: could not find bibtex key "NeumannMarsOrbiterLaser2003"
/home/runner/work/agu24workshop/agu24workshop/book/tut05_topography.ipynb:120029: WARNING: could not find bibtex key "HowatReferenceElevationModel2019"
```

Probably because there's no bibliography directive after the placeholder files were removed in #26. Adding one here following https://jupyterbook.org/en/stable/content/citations.html

Also updated the thumbnail hash on the front page for Tutorial 5 :crossed_fingers: