### PR TITLE
Tutorial 01: Mention "pygmt.Figure.savefig"

### DIFF
--- a/book/tut01_firstfigure.ipynb
+++ b/book/tut01_firstfigure.ipynb
@@ -216,10 +216,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d4ad78f6-22db-4999-98f3-69b70f29b17f",
+   "metadata": {},
+   "source": [
+    "### 1.3 Saving a figure to a file -- pygmt.Figure.savefig\n",
+    "To save the figure to a file you can use the [`pygmt.Figure.savefig`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.savefig) method, and pass the desired file name and extension to the `fname` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19fcd8e8-6cbe-4209-b619-73cc89acf0de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.savefig(fname=\"my_first_figure.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c9b6acaa-ffea-4c8a-bf2a-91b73070d06c",
    "metadata": {},
    "source": [
-    "### 1.3 Stacking approach of GMT / PyGMT\n",
+    "### 1.4 Stacking approach of GMT / PyGMT\n",
     "1. In GMT/PyGMT, plotting is achieved by layering new elements, meaning that each new element is stacked on top of the previous layers. \n",
     "Therefore, if you draw a black line in an earlier layer and then add a new layer (such as color filling), these new layers might cover the original black line, making it invisible.\n",
     "2. In a **same figure**, once you define region/projection before, you don't need to define again. "
@@ -503,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.6"
   },
   "panel-cell-order": [
    "eb4b43cc-dc76-45d1-a370-7266bd943910",

--- a/book/tut01_firstfigure.ipynb
+++ b/book/tut01_firstfigure.ipynb
@@ -230,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig.savefig(fname=\"my_first_figure.pdf\")"
+    "fig.savefig(fname=\"my_first_figure.png\")"
    ]
   },
   {

--- a/book/tut01_firstfigure.ipynb
+++ b/book/tut01_firstfigure.ipynb
@@ -219,7 +219,7 @@
    "id": "d4ad78f6-22db-4999-98f3-69b70f29b17f",
    "metadata": {},
    "source": [
-    "### 1.3 Saving a figure to a file -- pygmt.Figure.savefig\n",
+    "### 1.3 Saving a figure to a file -- [`pygmt.Figure.savefig`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.savefig)\n",
     "To save the figure to a file you can use the [`pygmt.Figure.savefig`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.Figure.savefig) method, and pass the desired file name and extension to the `fname` parameter."
    ]
   },


### PR DESCRIPTION
Based on questions during the workshop, I feel including `Figure.savefig` in Tutorial 1 makes sense.