### PR TITLE
Tutorial 2: Change "gdf" to "gpd" in variable name | Show output of ".head()" and ".crs" explicitly

### DIFF
--- a/book/tut01_firstfigure.ipynb
+++ b/book/tut01_firstfigure.ipynb
@@ -522,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.7"
   },
   "panel-cell-order": [
    "eb4b43cc-dc76-45d1-a370-7266bd943910",

--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -263,7 +263,7 @@
     "    + \"zipped-shapefile-with-wise-large-rivers-vector-line/zipped-shapefile-with-wise-large-rivers-vector-line/\"\n",
     "    + \"at_download/file/wise_large_rivers.zip\"\n",
     ")\n",
-    "# gdf_rivers_org = pd.read_file(\"wise_large_rivers.zip\")"
+    "# gdf_rivers_org = gpd.read_file(\"wise_large_rivers.zip\")"
    ]
   },
   {

--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -271,7 +271,7 @@
    "id": "f8db1757-f80d-4cc3-b650-83109eecc390",
    "metadata": {},
    "source": [
-    "Have a look at the values in the geometry column:"
+    "Have a look at the data and especially at the values in the geometry column:"
    ]
   },
   {
@@ -313,11 +313,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc67a58c-45f3-4819-9df4-04e5aa9d06f7",
+   "id": "c6a07d4d-ec70-4624-836b-41f713218f11",
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf_rivers = gdf_rivers_org.to_crs(\"EPSG:4326\")\n",
+    "gdf_rivers = gdf_rivers_org.to_crs(\"EPSG:4326\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd9b9f2b-d15b-4336-b2ee-4370bb6ffb25",
+   "metadata": {},
+   "source": [
+    "Again have a look at the coordinate system and the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06124f49-4dc7-4518-8ceb-b85257a30920",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdf_rivers.crs"
    ]
   },

--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -258,13 +258,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gpd_rivers_org = gpd.read_file(\n",
+    "gdf_rivers_org = gpd.read_file(\n",
     "    \"https://www.eea.europa.eu/data-and-maps/data/wise-large-rivers-and-large-lakes/\"\n",
     "    + \"zipped-shapefile-with-wise-large-rivers-vector-line/zipped-shapefile-with-wise-large-rivers-vector-line/\"\n",
     "    + \"at_download/file/wise_large_rivers.zip\"\n",
     ")\n",
-    "# gpd_rivers_org = pd.read_file(\"wise_large_rivers.zip\")\n",
-    "gpd_rivers_org.head()"
+    "# gdf_rivers_org = pd.read_file(\"wise_large_rivers.zip\")"
    ]
   },
   {
@@ -272,7 +271,43 @@
    "id": "f8db1757-f80d-4cc3-b650-83109eecc390",
    "metadata": {},
    "source": [
-    "Have a look at the values in the geometry column. The coordinates are currently not given in the geographic coordinate reference system (longitude/latitude) and have to be converted. This can be done directly with `GeoPandas`."
+    "Have a look at the values in the geometry column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "926955ee-3859-468b-9b41-0398ed6c7b99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf_rivers_org.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b868d284-23ff-4607-a950-de47da71f7cd",
+   "metadata": {},
+   "source": [
+    "The coordinates are currently not given in the geographic coordinate reference system (longitude/latitude):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f033930d-fe1c-4883-a27c-6a768bb29598",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf_rivers_org.crs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59edb4bf-9466-41a9-9cf6-f2ae3d7a5a0d",
+   "metadata": {},
+   "source": [
+    "Thus, they have to be converted which can be done directly with `GeoPandas`."
    ]
   },
   {
@@ -282,9 +317,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gpd_rivers_org.crs\n",
-    "gpd_rivers = gpd_rivers_org.to_crs(\"EPSG:4326\")\n",
-    "gpd_rivers.head()"
+    "gdf_rivers = gdf_rivers_org.to_crs(\"EPSG:4326\")\n",
+    "gdf_rivers.crs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "537e141d-6f64-4b99-9e30-75e1c217d3c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf_rivers.head()"
    ]
   },
   {
@@ -314,7 +358,7 @@
     "    frame=True,\n",
     ")\n",
     "\n",
-    "fig.plot(data=gpd_rivers, pen=\"0.5p,steelblue,solid\")\n",
+    "fig.plot(data=gdf_rivers, pen=\"0.5p,steelblue,solid\")\n",
     "\n",
     "fig.show(dpi=img_dpi)"
    ]
@@ -341,8 +385,8 @@
     "# Split the dataset into two subsets of shorter and longer rivers\n",
     "# Feel free to play around with the limit\n",
     "len_limit = 700000  # in meters\n",
-    "gpd_rivers_short = gpd_rivers[gpd_rivers[\"Shape_Leng\"] < len_limit]\n",
-    "gpd_rivers_long = gpd_rivers[gpd_rivers[\"Shape_Leng\"] > len_limit]\n",
+    "gdf_rivers_short = gdf_rivers[gdf_rivers[\"Shape_Leng\"] < len_limit]\n",
+    "gdf_rivers_long = gdf_rivers[gdf_rivers[\"Shape_Leng\"] > len_limit]\n",
     "\n",
     "\n",
     "fig = pygmt.Figure()\n",
@@ -357,11 +401,11 @@
     "\n",
     "# Plot the subsets differently and specify the text for the legend entries\n",
     "fig.plot(\n",
-    "    data=gpd_rivers_short,\n",
+    "    data=gdf_rivers_short,\n",
     "    pen=\"0.5p,orange\",\n",
     "    label=f\"shorter {len_limit} m+Hriver length+f9p\",\n",
     ")\n",
-    "fig.plot(data=gpd_rivers_long, pen=\"0.5p,darkred\", label=f\"longer {len_limit} m\")\n",
+    "fig.plot(data=gdf_rivers_long, pen=\"0.5p,darkred\", label=f\"longer {len_limit} m\")\n",
     "\n",
     "# Place the legend at the Top Left corner with an offset of 0.1 centimeters from the map frame\n",
     "# Add a box with semi-transparent (@30) white fill (+g) and a 0.1-points thick gray outline (+p)\n",
@@ -520,14 +564,14 @@
     ")\n",
     "\n",
     "pygmt.makecpt(\n",
-    "    cmap=\"SCM/oslo\", series=[gpd_rivers.Shape_Leng.min(), 1500000], reverse=True\n",
+    "    cmap=\"SCM/oslo\", series=[gdf_rivers.Shape_Leng.min(), 1500000], reverse=True\n",
     ")\n",
     "fig.colorbar(frame=[\"x+lriver length\", \"y+lm\"], position=\"+ef0.2c\")\n",
     "\n",
-    "for i_river in range(len(gpd_rivers)):\n",
+    "for i_river in range(len(gdf_rivers)):\n",
     "    fig.plot(\n",
-    "        data=gpd_rivers[gpd_rivers.index == i_river],\n",
-    "        zvalue=gpd_rivers.loc[i_river, \"Shape_Leng\"],\n",
+    "        data=gdf_rivers[gdf_rivers.index == i_river],\n",
+    "        zvalue=gdf_rivers.loc[i_river, \"Shape_Leng\"],\n",
     "        pen=\"0.5p\",\n",
     "        cmap=True,\n",
     "    )\n",
@@ -552,7 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Improvemets of Tutorial 2:

- Use "gdf" instead of "gpd" in variable name to avoid confusions 
- Split cells to show output of `crs`