### PR TITLE
Set GMT_DATA_SERVER="Oceania"

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  # pull_request:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  pull_request:
+  # pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/book/intro.md
+++ b/book/intro.md
@@ -15,7 +15,7 @@ tutorials for making maps 🗺️ and animations 🎦
 :gutter: 1
 
 :::{grid-item-card} Tutorial 1 - First figure 🚀 and Subplots / layout
-:img-top: \_images/595c695c25a21e4711d8c268a368ef6fee13a6d9d7918e1ebdb92d8b0bbd4475.png
+:img-top: \_images/c602786bf752e87289f43caedf9bfc40090944d450f721a51d8c952235fcc313.png
 :link: ./tut01_firstfigure.html
 by [Jing-Hui Tong](https://orcid.org/0009-0002-7195-3071)
 +++

--- a/book/tut03_spe_xarray.ipynb
+++ b/book/tut03_spe_xarray.ipynb
@@ -80,7 +80,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's use a PyGMT function to explore an Xarray DataArray. We can use the [`pygmt.datasets.load_earth_relief`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.datasets.load_earth_relief.html) function to load one of GMT's remote datasets. This will take longer the first time that it's run because GMT downloads the data from the GMT server. We'll specify the server in order to quicken download speeds to Washington, D.C., USA."
+    "Let's use a PyGMT function to explore an Xarray DataArray. We can use the [`pygmt.datasets.load_earth_relief`](https://www.pygmt.org/v0.13.0/api/generated/pygmt.datasets.load_earth_relief.html) function to load one of GMT's remote datasets. This will take longer the first time that it's run because GMT downloads the data from the GMT server.\n",
+    "You can specify the [`GMT_DATA_SERVER`](https://docs.generic-mapping-tools.org/6.5/gmt.conf.html#term-GMT_DATA_SERVER) in order to quicken download speeds to your location."
    ]
   },
   {
@@ -89,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pygmt.config(GMT_DATA_SERVER=\"NOAA\"):\n",
+    "with pygmt.config(GMT_DATA_SERVER=\"Oceania\"):\n",
     "    grid = pygmt.datasets.load_earth_relief(resolution=\"01d\")\n",
     "grid"
    ]


### PR DESCRIPTION
In hindsight, maybe using the NOAA server wasn't a good idea :sweat_smile: Changing to the default Oceania server instead.

**Preview** at https://www.generic-mapping-tools.org/agu24workshop/intro.html

Fixes the following error:

```python
Traceback (most recent call last):
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/jupyter_cache/executors/utils.py", line 58, in single_nb_execution
    executenb(
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/nbclient/client.py", line 1314, in execute
    return NotebookClient(nb=nb, resources=resources, km=km, **kwargs).execute()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/jupyter_core/utils/__init__.py", line 165, in wrapped
    return loop.run_until_complete(inner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/nbclient/client.py", line 709, in async_execute
    await self.async_execute_cell(
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/nbclient/client.py", line 1062, in async_execute_cell
    await self._check_raise_for_error(cell, cell_index, exec_reply)
  File "/home/runner/micromamba/envs/agu24workshop/lib/python3.12/site-packages/nbclient/client.py", line 918, in _check_raise_for_error
    raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
with pygmt.config(GMT_DATA_SERVER="NOAA"):
    grid = pygmt.datasets.load_earth_relief(resolution="01d")
grid
------------------

----- stderr -----
gmtread [NOTICE]: Remote data courtesy of GMT data server NOAA [http://noaa.generic-mapping-tools.org]
----- stderr -----
gmtread [NOTICE]: SRTM15 Earth Relief v2.7 at 1x1 arc degrees reduced by Gaussian Cartesian filtering (314.5 km fullwidth) [Tozer et al., 2019].
----- stderr -----
gmtread [NOTICE]:   -> Download grid file [112K]: earth_relief_01d_g.grd
----- stderr -----
gmtread [ERROR]: Libcurl Error: Could not connect to server
----- stderr -----
gmtread [ERROR]: Unable to obtain remote file @earth_relief_01d_g.grd
----- stderr -----
gmtread [NOTICE]:   -> Download grid file [112K]: earth_relief_01d_g.grd
----- stderr -----
gmtread [ERROR]: Libcurl Error: Could not connect to server
----- stderr -----
gmtread [ERROR]: Unable to obtain remote file @earth_relief_01d_g.grd
----- stderr -----
gmtread [ERROR]: File @earth_relief_01d_g.grd not found
----- stderr -----
[Session pygmt-session (3)]: Error returned from GMT API: GMT_FILE_NOT_FOUND (16)
------------------
```

Also note to future self, don't publish a tag until double-checking that the docs were built correctly.