### PR TITLE
Tutorial 2: Fix typo

### DIFF
--- a/book/tut02_spe_pd_gpd.ipynb
+++ b/book/tut02_spe_pd_gpd.ipynb
@@ -204,7 +204,7 @@
     "pygmt.makecpt(cmap=\"SCM/navia\", series=[0, 500], reverse=True)\n",
     "fig.colorbar(frame=[\"xa100f50+lhypocentral depth\", \"y+lkm\"], position=\"+ef0.2c\")\n",
     "\n",
-    "# Plot the epicenters as color- and size-coded circels based on depth or magnitude\n",
+    "# Plot the epicenters as color- and size-coded circles based on depth or magnitude\n",
     "fig.plot(\n",
     "    x=df_jp_eqs.longitude,\n",
     "    y=df_jp_eqs.latitude,\n",


### PR DESCRIPTION
Just a minor typo fix; no code or content changes. Found by `typos`.